### PR TITLE
Update syntax to Terraform 0.12, use Google priorities

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,28 +1,24 @@
-locals {
-  mx_server_domains = [
-    "aspmx.l.google.com",
-    "alt1.aspmx.l.google.com",
-    "alt2.aspmx.l.google.com",
-    "alt3.aspmx.l.google.com",
-    "alt4.aspmx.l.google.com",
-  ]
-}
-
 resource "cloudflare_record" "mx" {
-  count = "${length(local.mx_server_domains)}"
+  for_each = {
+    main = { server = "aspmx.l.google.com", priority = 1 }
+    alt1 = { server = "alt1.aspmx.l.google.com", priority = 5 }
+    alt2 = { server = "alt2.aspmx.l.google.com", priority = 5 }
+    alt3 = { server = "alt3.aspmx.l.google.com", priority = 10 }
+    alt4 = { server = "alt4.aspmx.l.google.com", priority = 10 }
+  }
 
-  domain = "${var.domain}"
-  name = "${var.sub_domain}"
-  value = "${local.mx_server_domains[count.index]}"
-  priority = "${count.index + 1}"
-  type = "MX"
-  ttl = "${var.ttl}"
+  zone_id  = var.zone_id
+  name     = var.sub_domain
+  type     = "MX"
+  value    = each.value.server
+  ttl      = var.ttl
+  priority = each.value.priority
 }
 
 resource "cloudflare_record" "spf" {
-  domain = "${var.domain}"
-  name = "${var.sub_domain}"
-  type = "TXT"
-  value = "v=spf1 include:_spf.google.com ~all"
-  ttl = "${var.ttl}"
+  zone_id = var.zone_id
+  name    = var.sub_domain
+  type    = "TXT"
+  value   = "v=spf1 include:_spf.google.com ~all"
+  ttl     = var.ttl
 }


### PR DESCRIPTION
Update syntax to Terraform 0.12 including the use of `for_each`
meta-argument which allows assigning specific priorities to alt MX
servers as recommended by Google in GSuite setup.
